### PR TITLE
Grupper vedlegg-elementer med section for å få overskrift til å leses opp når man navigerer inn i elementet

### DIFF
--- a/components/Vedlegg.tsx
+++ b/components/Vedlegg.tsx
@@ -93,7 +93,7 @@ const filListeReducer = (filListe: FilData[], action: ActionType) => {
 
 const initialState: FilData[] = [];
 
-export const VedleggContainer = styled.article<{
+export const VedleggContainer = styled.section<{
     $extraMargin?: boolean;
 }>`
     ${(props) => props.$extraMargin && 'margin-bottom: 60px'};


### PR DESCRIPTION
Bytt fra article til section som wrapper element for vedlegg, da article tydeligvis ikke laget en gruppe/region i NVDA.