### PR TITLE
Ignore odd-numbered releases of node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    ignore:
+      - dependency-name: 'node'
+        versions: '/^\d+[13579]-alpine$/'


### PR DESCRIPTION
These are never moved to LTS status (long-term support), and node doc states that 'Production applications should only use Active LTS or Maintenance LTS releases'.