### PR TITLE
ci(deps): upgrade GitHub Actions

### DIFF
--- a/.github/workflows/alert-deploy.yml
+++ b/.github/workflows/alert-deploy.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: deploy to prod
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -42,7 +42,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: deploy to dev
         uses: nais/deploy/actions/deploy@v2
         env:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -19,8 +19,8 @@ jobs:
       id-token: 'write'
       packages: 'read'
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
         language: ['javascript']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: nais/deploy/actions/deploy@v2
         env:
           DRY_RUN: false

--- a/.github/workflows/preprod-alt.yml
+++ b/.github/workflows/preprod-alt.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: nais/deploy/actions/deploy@v2
         env:
           DRY_RUN: false

--- a/.github/workflows/preprod-delingslenke.yml
+++ b/.github/workflows/preprod-delingslenke.yml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: nais/deploy/actions/deploy@v2
         env:
           DRY_RUN: false

--- a/.github/workflows/preprod.yml
+++ b/.github/workflows/preprod.yml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: nais/deploy/actions/deploy@v2
         env:
           DRY_RUN: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       contents: 'read'
       packages: 'read'
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: 'npm'
@@ -27,7 +27,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with mock
         run: npm run build:mock
-      - uses: cypress-io/github-action@v6
+      - uses: cypress-io/github-action@v7
         with:
           install: false
           start: npm run start:with:test
@@ -35,7 +35,7 @@ jobs:
           config: video=false
           config-file: cypress.config.ts
       - name: Upload screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: cypress-screenshots


### PR DESCRIPTION
## Changes

| Dependency | Previous | New | Assessed release | Release date |
| --- | --- | --- | --- | --- |
| `actions/checkout` | `v5` | `v7` | [`v7.0.1`](https://github.com/actions/checkout/releases/tag/v7.0.1) | 2026-07-20 |
| `actions/setup-node` | `v5` | `v7` | [`v7.0.0`](https://github.com/actions/setup-node/releases/tag/v7.0.0) | 2026-07-14 |
| `actions/upload-artifact` | `v4` | `v7` | [`v7.0.1`](https://github.com/actions/upload-artifact/releases/tag/v7.0.1) | 2026-04-10 |
| `cypress-io/github-action` | `v6` | `v7` | [`v7.4.2`](https://github.com/cypress-io/github-action/releases/tag/v7.4.2) | 2026-08-13 |

All targets were released more than seven full days before 2026-08-25. The workflows keep major-only references so they receive fixes within the selected major.

## Sources

- [Checkout changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Setup Node releases](https://github.com/actions/setup-node/releases)
- [Upload Artifact releases](https://github.com/actions/upload-artifact/releases)
- [Cypress Action changelog](https://github.com/cypress-io/github-action/blob/master/CHANGELOG.md)
- [GitHub documentation for action release tags](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/using-immutable-releases-and-tags-to-manage-your-actions-releases)

## Risks to review

- Checkout v7 rejects unsafe fork checkouts for `pull_request_target` and `workflow_run`. These workflows use `pull_request`, `push`, and `workflow_call`, so the guard does not affect their current triggers.
- Setup Node v7 removes its fallback `NODE_AUTH_TOKEN`. Both install jobs already pass `secrets.GITHUB_TOKEN` explicitly.
- Upload Artifact and Cypress Action now run on Node 24 and require runner 2.327.1 or newer. Every job uses GitHub-hosted `ubuntu-latest`.
- Cypress Action keeps the inputs used here: `install`, `start`, `wait-on`, `config`, and `config-file`.

## Migration work and decisions

No workflow migration was needed. Existing authentication, caching, Cypress startup, and screenshot upload settings remain valid.

The stack uses the latest eligible major instead of Dependabot PR #494's older v6 targets for Checkout and Setup Node.

## Validation

- `mise exec -- npm run build:mock`: passed in a clean sandbox-native copy.
- The mounted workspace build reached standalone tracing, then hit the repository's documented `ENOENT` and `ENOTDIR` filesystem failure.
- `mise exec -- npm run lint`: blocked by the existing `@typescript-eslint/no-unused-expressions` error in `cypress/e2e/unauthenticated.cy.js`. This PR does not change source files or lint configuration.
- GitHub checks: two Build and Test jobs, CodeQL analysis, and CodeQL status passed.
