### PR TITLE
fix(aksel): migrate custom styling tokens

### DIFF
--- a/components/Fil.tsx
+++ b/components/Fil.tsx
@@ -32,7 +32,7 @@ export const FilePanel = styled(Panel)`
   }
   .filename {
     grid-area: filename;
-    color: var(--a-text-subtle);
+    color: var(--ax-text-neutral-subtle);
     justify-items: left;
     white-space: nowrap;
     overflow: hidden;
@@ -45,7 +45,7 @@ export const FilePanel = styled(Panel)`
     }
   }
   .documentarchive {
-    color: var(--a-text-subtle);
+    color: var(--ax-text-neutral-subtle);
     grid-area: fileinfo;
   }
   .fileinfo {
@@ -73,7 +73,7 @@ export const FilePanel = styled(Panel)`
 
   padding: 12px 8px;
 
-  ${(props) => props.type === FIL_STATUS.FEIL && 'border-color: var(--a-surface-danger)'};
+  ${(props) => props.type === FIL_STATUS.FEIL && 'border-color: var(--ax-border-danger)'};
 
   @media only screen and (max-width: 600px) {
     grid-template-areas:
@@ -100,18 +100,18 @@ const StyledButton = styled.div`
 
 const StyledProvIgjenButton = styled(StyledButton)`
   label {
-    background-color: var(--a-surface-action-subtle-hover);
+    background-color: var(--ax-bg-accent-moderate-hover);
   }
   label:hover {
-    background-color: var(--a-surface-action-hover);
-    color: var(--a-text-on-inverted);
+    background-color: var(--ax-bg-accent-strong-hover);
+    color: var(--ax-text-accent-contrast);
   }
 `;
 
 const StyledTertiaryButton = styled(StyledButton)`
   @media only screen and (max-width: 600px) {
     :first-child {
-      border-top: 1px solid var(--a-border-divider);
+      border-top: 1px solid var(--ax-border-neutral-subtle);
     }
     :first-child:last-child {
       margin-bottom: -0.75rem;

--- a/components/FilUploadIcon.tsx
+++ b/components/FilUploadIcon.tsx
@@ -23,10 +23,10 @@ const StyledDiv = styled.div`
 `;
 
 const ErrorStyled = styled(StyledDiv)`
-  background-color: var(--a-surface-danger-subtle);
+  background-color: var(--ax-bg-danger-soft);
 
   > * {
-    color: var(--a-surface-danger);
+    color: var(--ax-text-danger-decoration);
   }
 `;
 
@@ -46,10 +46,10 @@ function ErrorFileIcon({ filnavn }: { filnavn: string }) {
 }
 
 const AlreadyUploadedStyled = styled(StyledDiv)`
-  background-color: var(--a-bg-subtle);
+  background-color: var(--ax-bg-neutral-soft);
 
   > * {
-    color: var(--a-text-subtle);
+    color: var(--ax-text-neutral-subtle);
   }
 `;
 
@@ -69,10 +69,10 @@ function AlreadyUploadedFileIcon({ filnavn }: { filnavn: string }) {
 }
 
 const UploadingStyled = styled(StyledDiv)`
-  background-color: var(--a-surface-info-subtle);
+  background-color: var(--ax-bg-info-soft);
 
   > * {
-    color: var(--a-icon-info);
+    color: var(--ax-text-info-decoration);
   }
 `;
 
@@ -92,9 +92,9 @@ function UploadingFileIcon({ filnavn }: { filnavn: string }) {
 }
 
 const SuccessStyled = styled(StyledDiv)`
-  background-color: var(--a-surface-success-subtle);
+  background-color: var(--ax-bg-success-soft);
   > * {
-    color: var(--a-icon-success);
+    color: var(--ax-text-success-decoration);
   }
 `;
 

--- a/components/Filvelger.tsx
+++ b/components/Filvelger.tsx
@@ -22,9 +22,8 @@ const StyledUpload = styled.input`
 
 const FilvelgerForm = styled.form`
   input[type='file']:focus + label {
-    box-shadow:
-      inset 0 0 0 2px var(--a-border-action),
-      var(--a-shadow-focus);
+    outline: 3px solid var(--ax-border-focus);
+    outline-offset: 3px;
   }
 `;
 

--- a/components/Kvittering.tsx
+++ b/components/Kvittering.tsx
@@ -20,21 +20,21 @@ const SjekkBoksListe = styled.ul`
   padding-left: 0;
 
   li:not(:last-child) {
-    padding-bottom: var(--a-spacing-4);
+    padding-bottom: var(--ax-space-16);
   }
 `;
 
 const StyledSection = styled.section`
-  margin-bottom: var(--a-spacing-8);
+  margin-bottom: var(--ax-space-32);
 `;
 
 const BoksMedMargin = styled.div`
-  margin-top: var(--a-spacing-4);
-  margin-bottom: var(--a-spacing-4);
+  margin-top: var(--ax-space-16);
+  margin-bottom: var(--ax-space-16);
 `;
 
 const StyledAlert = styled(Alert)`
-  margin-bottom: var(--a-spacing-11);
+  margin-bottom: var(--ax-space-44);
 `;
 
 function ettersendingsTekst({ kvprops, t }: { kvprops: KvitteringsDto; t: TFunction }) {

--- a/components/LastOppVedlegg.tsx
+++ b/components/LastOppVedlegg.tsx
@@ -23,7 +23,7 @@ import { Linje } from './common/Linje';
 
 const FristForOpplastingInfo = styled(Alert)`
   border: 0;
-  border-bottom: 1px solid var(--a-border-strong);
+  border-bottom: 1px solid var(--ax-border-neutral-strong);
   padding-bottom: 4px;
   border-radius: 0px;
   margin-bottom: 24px;
@@ -33,14 +33,14 @@ const PaddedVedlegg = styled.div`
   > * {
     margin-top: 16px;
   }
-  margin-bottom: var(--a-spacing-10);
+  margin-bottom: var(--ax-space-40);
 `;
 
 const SistLagret = styled(BodyShort)`
   display: flex;
   justify-content: center;
-  margin-top: var(--a-spacing-5);
-  margin-bottom: var(--a-spacing-5);
+  margin-top: var(--ax-space-20);
+  margin-bottom: var(--ax-space-20);
 `;
 
 export interface LastOppVedleggdProps {

--- a/components/SoknadHeader.tsx
+++ b/components/SoknadHeader.tsx
@@ -9,7 +9,7 @@ export interface SoknadHeaderProps {
 }
 
 export const StyledDetail = styled(BodyShort)`
-  color: var(--a-gray-900);
+  color: var(--ax-text-neutral);
 `;
 
 export const Style = styled.div`
@@ -29,7 +29,7 @@ export const Style = styled.div`
 
 export const Line = styled.div`
   width: 100vw;
-  border-bottom: 0.3rem solid var(--a-deepblue-200);
+  border-bottom: 0.3rem solid var(--ax-bg-brand-blue-moderate);
   margin-left: calc(50% - 50vw);
 `;
 

--- a/components/ValideringsRamme.tsx
+++ b/components/ValideringsRamme.tsx
@@ -11,17 +11,16 @@ interface ValideringsRammeProps {
 
 const FeilRamme = styled.div`
   &.visFeil {
-    border: 1px solid var(--a-border-danger);
-    box-shadow: 0 0 0 1px var(--a-border-danger);
+    border: 1px solid var(--ax-border-danger);
+    box-shadow: 0 0 0 1px var(--ax-border-danger);
     border-radius: 8px;
 
     :hover {
-      border-color: var(--a-border-action);
+      border-color: var(--ax-border-accent);
     }
     :focus {
-      box-shadow:
-        0 0 0 1px var(--a-border-danger),
-        var(--a-shadow-focus);
+      outline: 3px solid var(--ax-border-focus);
+      outline-offset: 3px;
     }
     margin-bottom: 0.5rem;
   }

--- a/components/Vedlegg.tsx
+++ b/components/Vedlegg.tsx
@@ -85,7 +85,7 @@ export const VedleggContainer = styled.section<{
 `;
 
 export const VedleggPanel = styled(Panel)`
-  background-color: var(--a-bg-subtle);
+  background-color: var(--ax-bg-neutral-soft);
   border-radius: 8px;
   padding: 24px;
   @media only screen and (max-width: 600px) {
@@ -146,15 +146,15 @@ const List = styled.ul`
 `;
 
 const ReadMoreStyled = styled(ReadMore)`
-  margin-top: var(--a-spacing-4);
+  margin-top: var(--ax-space-16);
   .mb {
-    margin-bottom: var(--a-spacing-4);
+    margin-bottom: var(--ax-space-16);
   }
   .prefix {
-    font-weight: var(--a-font-weight-bold);
+    font-weight: var(--ax-font-weight-bold);
   }
   .content {
-    margin-left: var(--a-spacing-1);
+    margin-left: var(--ax-space-4);
   }
 `;
 

--- a/components/VedleggsListe.tsx
+++ b/components/VedleggsListe.tsx
@@ -32,7 +32,7 @@ const Style = styled.div`
 `;
 
 const StyledButtonContainer = styled.div`
-  margin-bottom: var(--a-spacing-11);
+  margin-bottom: var(--ax-space-44);
 `;
 
 export interface VedleggsListeProps {

--- a/components/common/ButtonContainer.tsx
+++ b/components/common/ButtonContainer.tsx
@@ -14,10 +14,10 @@ export const ButtonContainer = styled.div<ButtonContainerProps>`
       max-width: unset;
     }
   }
-  gap: var(--a-spacing-5);
+  gap: var(--ax-space-20);
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: var(--a-spacing-5);
+  margin-bottom: var(--ax-space-20);
   flex-direction: ${(props) => (props.$reverse ? 'row-reverse' : 'row')};
   justify-content: ${(props) => (props.$reverse ? 'flex-end' : 'flex-start')};
 

--- a/components/common/Linje.tsx
+++ b/components/common/Linje.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const Linje = styled.div`
-  border-bottom: 1px solid var(--a-border-strong);
+  border-bottom: 1px solid var(--ax-border-neutral-strong);
   margin-top: 1.5rem;
   margin-bottom: 1.5rem;
 `;

--- a/components/textStyle.tsx
+++ b/components/textStyle.tsx
@@ -8,7 +8,7 @@ export const Bold = styled.span`
 
 export const ErrorMessageWithDot = styled(ErrorMessage)`
   display: flex;
-  gap: var(--a-spacing-2);
+  gap: var(--ax-space-8);
   &::before {
     content: '•';
   }

--- a/cypress/e2e/dokumentinnsendingTest.cy.js
+++ b/cypress/e2e/dokumentinnsendingTest.cy.js
@@ -2,6 +2,22 @@
 import translations from '../../assets/locales/nb/translation.json';
 
 describe('Tester dokumentinnsendingsløpet', () => {
+  beforeEach(() => {
+    cy.intercept('PATCH', /\/sendinn\/api\/backend\/frontend\/v1\/soknad\/[^/]+$/).as('updateApplication');
+    cy.intercept('POST', /\/sendinn\/api\/backend\/frontend\/v1\/soknad\/[^/]+\/vedlegg\/[^/]+\/fil$/).as('uploadFile');
+    cy.intercept('PATCH', /\/sendinn\/api\/backend\/frontend\/v1\/soknad\/[^/]+\/vedlegg\/[^/]+$/).as(
+      'updateAttachment',
+    );
+    cy.intercept('POST', /\/sendinn\/api\/backend\/frontend\/v1\/soknad\/[^/]+\/vedlegg$/).as('createAttachment');
+    cy.intercept('DELETE', /\/sendinn\/api\/backend\/frontend\/v1\/soknad\/[^/]+\/vedlegg\/[^/]+\/fil\/[^/]+$/).as(
+      'deleteFile',
+    );
+    cy.intercept('DELETE', /\/sendinn\/api\/backend\/frontend\/v1\/soknad\/[^/]+\/vedlegg\/[^/]+$/).as(
+      'deleteAttachment',
+    );
+    cy.intercept('POST', /\/sendinn\/api\/backend\/frontend\/v1\/sendInn\/[^/]+$/).as('submitApplication');
+  });
+
   it('Går igjennom fra åpning av url som oppretter søknad til kvitteringssiden', () => {
     cy.visit(
       '/opprettSoknadResource?skjemanummer=NAV%2054-00.04&sprak=NO_NB&erEttersendelse=false&vedleggsIder=C1,W1,G2',
@@ -9,16 +25,19 @@ describe('Tester dokumentinnsendingsløpet', () => {
 
     // Bekrefter at siden er rendret
     cy.get('[data-cy="nesteStegKnapp"]').should('be.visible').click();
+    cy.wait('@updateApplication');
     cy.injectAxe();
     cy.checkA11y('#__next');
 
     // Laster opp fil på hoveddokument
     cy.get('[data-cy="filvelgerKnapp"]').click();
     cy.get('[data-cy="filvelgerKnapp"]').selectFile('cypress/fixtures/MarcusAurelius.jpeg');
+    cy.wait('@uploadFile');
     cy.get('[data-cy="fileUploadSuccessIkon"]').should('be.visible');
 
     // Går til vedleggsiden
     cy.get('[data-cy="nesteStegKnapp"]').click();
+    cy.wait('@updateApplication');
 
     cy.get('[data-cy="filvelgerKnapp"]').should('have.length', 3);
     cy.checkA11y('#__next');
@@ -30,6 +49,7 @@ describe('Tester dokumentinnsendingsløpet', () => {
         cy.get('[data-cy="lasterOppNaaRadio"]').should('be.checked').should('have.value', 'LasterOpp');
         cy.get('[data-cy="filvelgerKnapp"]').click();
         cy.get('[data-cy="filvelgerKnapp"]').selectFile('cypress/fixtures/MarcusAurelius.jpeg');
+        cy.wait('@uploadFile');
         cy.get('[data-cy="fileUploadSuccessIkon"]').should('be.visible');
         cy.get('[data-cy="filvelgerKnapp"]').should('be.visible');
       });
@@ -39,6 +59,7 @@ describe('Tester dokumentinnsendingsløpet', () => {
       .eq(1)
       .within(() => {
         cy.get('[data-cy="sendSenereRadio"]').click();
+        cy.wait('@updateAttachment');
         cy.get('[data-cy="sendSenereRadio"]').should('be.checked');
       });
 
@@ -46,6 +67,7 @@ describe('Tester dokumentinnsendingsløpet', () => {
       .eq(2)
       .within(() => {
         cy.get('[data-cy="sendSenereRadio"]').click();
+        cy.wait('@updateAttachment');
         cy.get('[data-cy="sendSenereRadio"]').should('be.checked');
       });
 
@@ -58,6 +80,7 @@ describe('Tester dokumentinnsendingsløpet', () => {
         cy.get('input').type('Ekstra vedlegg #1');
         cy.contains(translations.soknad.vedlegg.annet.bekreft).click();
       });
+    cy.wait('@createAttachment');
     cy.get('[data-cy="VedleggContainer"]').should('have.length', 4);
 
     // Laster opp to filer, og sletter den ene
@@ -66,9 +89,12 @@ describe('Tester dokumentinnsendingsløpet', () => {
       .within(() => {
         cy.get('[data-cy="filvelgerKnapp"]').click();
         cy.get('[data-cy="filvelgerKnapp"]').should('be.visible').selectFile('cypress/fixtures/MarcusAurelius.jpeg');
+        cy.wait('@uploadFile');
         cy.get('[data-cy="filvelgerKnapp"]').should('be.visible').selectFile('cypress/fixtures/MarcusAurelius.jpeg');
+        cy.wait('@uploadFile');
         cy.get('[data-cy="fileUploadSuccessIkon"]').should('have.length', 2);
         cy.get('[data-cy="slettFilKnapp"]').eq(1).click();
+        cy.wait('@deleteFile');
         cy.get('[data-cy="fileUploadSuccessIkon"]').should('have.length', 1);
       });
 
@@ -80,6 +106,7 @@ describe('Tester dokumentinnsendingsløpet', () => {
         cy.get('input').type('Ekstra vedlegg #2');
         cy.contains(translations.soknad.vedlegg.annet.bekreft).click();
       });
+    cy.wait('@createAttachment');
 
     cy.get('[data-cy="VedleggContainer"]').should('have.length', 5);
     cy.get('[data-cy="VedleggContainer"]')
@@ -87,6 +114,7 @@ describe('Tester dokumentinnsendingsløpet', () => {
       .within(() => {
         cy.contains(translations.soknad.vedlegg.annet.slett).click();
       });
+    cy.wait('@deleteAttachment');
     cy.get('[data-cy="VedleggContainer"]').should('have.length', 4);
 
     cy.checkA11y('#__next');
@@ -95,6 +123,7 @@ describe('Tester dokumentinnsendingsløpet', () => {
     cy.get('[data-cy="sendTilNAVKnapp"]').click();
 
     cy.get('[data-cy="jaFellesModalKnapp"]').filter(':visible').should('be.visible').click();
+    cy.wait('@submitApplication');
 
     cy.get('[data-cy="kvitteringOverskrift"]').should('be.visible');
     cy.checkA11y('#__next');

--- a/cypress/e2e/dokumentinnsendingTest.cy.js
+++ b/cypress/e2e/dokumentinnsendingTest.cy.js
@@ -118,6 +118,7 @@ describe('Tester dokumentinnsendingsløpet', () => {
     cy.get('[data-cy="VedleggContainer"]').should('have.length', 4);
 
     cy.checkA11y('#__next');
+    cy.get('[data-cy="valideringsfeil"]').should('not.exist');
 
     // Sender inn
     cy.get('[data-cy="sendTilNAVKnapp"]').click();

--- a/cypress/e2e/vedleggsvalg.cy.js
+++ b/cypress/e2e/vedleggsvalg.cy.js
@@ -41,6 +41,7 @@ describe('Tester validering', () => {
         cy.get('[data-cy="filvelgerKnapp"]').selectFile('cypress/fixtures/MarcusAurelius.jpeg');
         cy.get('[data-cy="fileUploadSuccessIkon"]').should('be.visible');
         cy.get('[data-cy="VedleggsKommentar"]').type('Test beskrivelse');
+        cy.get('[data-cy="VedleggsKommentar"]').blur();
       });
 
     cy.get('[data-cy="valideringsfeil"]').within(() => {
@@ -55,10 +56,14 @@ describe('Tester validering', () => {
         cy.get('input').its('length').should('eq', 4);
 
         cy.get('[data-cy="harIkkeDokumentasjonenRadio"]').click();
+        cy.get('@patchVedlegg.all').should('have.length', 2);
         cy.get('[data-cy="harIkkeDokumentasjonenRadio"]').should('be.checked');
         cy.get('[data-cy="sendSenereRadio"]').click();
+        cy.get('@patchVedlegg.all').should('have.length', 3);
         cy.get('[data-cy="sendSenereRadio"]').should('be.checked');
         cy.get('[data-cy="VedleggsKommentar"]').type('Test beskrivelse');
+        cy.get('[data-cy="VedleggsKommentar"]').blur();
+        cy.get('@patchVedlegg.all').should('have.length', 4);
 
         cy.get('input').its('length').should('eq', 3);
         cy.get('[data-cy="paakrevdAlert"]').should('not.exist');
@@ -92,9 +97,13 @@ describe('Tester validering', () => {
       .within(() => {
         cy.get('input').its('length').should('eq', 7);
         cy.get('[data-cy="harIkkeDokumentasjonenRadio"]').click();
+        cy.get('@patchVedlegg.all').should('have.length', 5);
         cy.get('[data-cy="harIkkeDokumentasjonenRadio"]').should('be.checked');
         cy.get('[data-cy="VedleggsKommentar"]').type('Test beskrivelse');
+        cy.get('[data-cy="VedleggsKommentar"]').blur();
+        cy.get('@patchVedlegg.all').should('have.length', 6);
         cy.get('[data-cy="levertTidligereRadio"]').click();
+        cy.get('@patchVedlegg.all').should('have.length', 7);
         cy.get('[data-cy="levertTidligereRadio"]').should('be.checked');
         cy.get('input').its('length').should('eq', 6);
       });


### PR DESCRIPTION
Restore custom colors, spacing, borders, and focus styles after the Aksel 8 upgrade removed the legacy token aliases.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>